### PR TITLE
restructure for consistency + new pags in gt-strtd

### DIFF
--- a/get-started/first-steps.mdx
+++ b/get-started/first-steps.mdx
@@ -1,0 +1,51 @@
+---
+title: First Steps
+description: 'These are the steps you have to take to setup Ocotomind'
+icon: 'lightbulb'
+---
+
+## Register Your project
+
+You need an account in order to get started. We do not feature self service yet. Therefore, please use our "join the waitinglist" button on our front page.
+<Frame caption="Join the waitlist">
+ <img src="/get-started/images/join-the-waitlist.png" alt="join the waitlist" />
+</Frame>
+
+We will reach out for the details and create an account for you.
+
+<Info>In the coming weeks we will replace this process with a self-service sign-up.</Info>
+
+## We Need a URL
+
+We will ask for a url. It is required to be able to create test cases. The url needs to be publicly accessible. Most likely it is the url of your live system.
+Depending on the type of test cases an account to your live system might also be required.
+You will receive an API token from us which will allow you to trigger test cases on pull requests.
+
+For the time being we will exchange all information via email.
+
+<Info>Going forward the self service sign-up mentioned before will also cover this step, including API token management.</Info>
+
+## Test Cases
+
+Now that we signed you up and that we exchanged the necessary information, test cases are the next thing needed.
+
+**For now we will create the test cases for you.** We will ask you for the most common cases and we will create 5 to 10 of them.
+
+<Warning>We will notify you, once we are done with test case creation.</Warning>
+
+<Info>A test case editor is on our list of things to do and will replace this part of the process. This way you will be able to compose test cases on your own and at your own speed. The editor will evolve into an AI powered bot which is taking over more and more of the work.</Info>
+
+## CI/CD Integration
+
+Now it is time to integrate Octomind into your CI/CD pipeline. If you are on [GitHub](/get-started/quickstart-GitHub) or on [Azure DevOps](/get-started/quickstart-Azure) you can use our pre-packaged integrations from GitHub. You will find all information in the respecitve quickstart sections of this documentation.
+
+<Info>Currently it is only possible to trigger from Pull Requests since we can comment test results back. Going forward we will have an option to trigger test cases from our app directly or scheduled.</Info>
+
+In case you are on a different CI/CD pipeline, you will have to use our API to trigger test cases on pull requests. Typically it is possible to add custom scripts into your pipeline. However, you will not be able to recieve test results directly within your pipeline. Instead you have to review test runs directly within our app.
+
+<Info>Our integerations are all open source. Feel free to contribute to them or to compose new ones for other CI/CD pipelines. We are happy to take over and further maintain them.</Info>
+
+
+## Test Results
+
+You will receive test results directly within your CI/CD pipeline comments. Each test case will be listed with a deep link to the test results. Please have a look at the [Test Results](/get-started/test-results) section of this documentation for details.


### PR DESCRIPTION
moved top level pages into get-started folder for consistency. All other sections are in their respective folders as well.
Add pages for "first steps" & "test results" in get-started section. Changed links in other pages to reflect new folder structure.