### PR TITLE
always use relative img paths

### DIFF
--- a/account-view/account.mdx
+++ b/account-view/account.mdx
@@ -9,7 +9,7 @@ You can add unlimited projects to your organization.
 
 <Frame caption="automatically created organization, 08/2024">
   <img
-    src="images/accounts/orga-name.png"
+    src="/images/accounts/orga-name.png"
     alt="organization created automatically"
     width="300"
   />
@@ -19,7 +19,7 @@ You can add unlimited projects to your organization.
 
 <Frame caption="'organization' and 'my account' settings, 08/2024">
   <img
-    src="images/accounts/account-orga-settings.png"
+    src="/images/accounts/account-orga-settings.png"
     alt="organization and my account settings"
   />
 </Frame>
@@ -27,14 +27,17 @@ You can add unlimited projects to your organization.
 Your organization can have unlimited `users`. You can add and manage them in the `organization` settings.
 
 <Frame caption="organization settings, 08/2024">
-  <img src="images/accounts/my-orga-settings.png" alt="organization settings" />
+  <img
+    src="/images/accounts/my-orga-settings.png"
+    alt="organization settings"
+  />
 </Frame>
 
 Just as your organization settings you can adjust your personal `account` settings.
 
 <Frame caption="personal account settings, 08/2024">
   <img
-    src="images/accounts/my-account-settings.png"
+    src="/images/accounts/my-account-settings.png"
     alt="personal account settings"
   />
 </Frame>

--- a/account-view/projects.mdx
+++ b/account-view/projects.mdx
@@ -10,7 +10,7 @@ You can run your test **against a different URL** while keeping the subpaths - t
 
 <Frame caption="test target url of a project, 08/2024">
   <img
-    src="images/accounts/test-target.png"
+    src="/images/accounts/test-target.png"
     alt="test target url of a project"
   />
 </Frame>
@@ -19,14 +19,14 @@ Projects are listed in the hamburger menu under your organization.
 of the organization.
 
 <Frame caption="project list, 08/2024">
-  <img src="images/accounts/project-list.png" alt="project list" />
+  <img src="/images/accounts/project-list.png" alt="project list" />
 </Frame>
 
 You can always create another project if you need to **test multiple websites**. The tests won't be shared between them.
 
 <Frame caption="new project dialogue, 08/2024">
   <img
-    src="images/accounts/new-project.png"
+    src="/images/accounts/new-project.png"
     alt="new project dialogue"
     width="300"
   />
@@ -39,5 +39,5 @@ Click on the `gear icon` to access `project settings` to:
 - set-up project api keys
 
 <Frame caption="project settings, 08/2024">
-  <img src="images/accounts/project-settings.png" alt="project setting" />
+  <img src="/images/accounts/project-settings.png" alt="project setting" />
 </Frame>

--- a/account-view/test-cases.mdx
+++ b/account-view/test-cases.mdx
@@ -10,7 +10,7 @@ It is the place where you can add, edit or delete test cases. From here, you can
 
 <Frame caption="'test cases' section in 'project overview', 08/2024">
   <img
-    src="images/accounts/test-cases-section.png"
+    src="/images/accounts/test-cases-section.png"
     alt="test cases section in project overview"
   />
 </Frame>
@@ -18,5 +18,5 @@ It is the place where you can add, edit or delete test cases. From here, you can
 <div class="mt-8" />
 
 <Frame caption="'test cases' page view, 08/2024">
-  <img src="images/accounts/test-cases-page.png" alt="test cases page view" />
+  <img src="/images/accounts/test-cases-page.png" alt="test cases page view" />
 </Frame>

--- a/account-view/test-reports.mdx
+++ b/account-view/test-reports.mdx
@@ -12,7 +12,7 @@ Test reports are tied to a single target execution URL, so one specific deployme
 
 <Frame caption="'test report' list in the 'project overview' in the app, 08/2024">
   <img
-    src="images/accounts/test-report-list.png"
+    src="/images/accounts/test-report-list.png"
     alt="test report list in the project overview in the ap, screenshot 08/2024"
   />
 </Frame>
@@ -33,7 +33,7 @@ If you integrated Octomind into your [CI pipeline](/integrations-overview), we w
 
 <Frame caption="Example of Octomind test results in a commit comment, 09/2023">
   <img
-    src="images/Octomind-test-results-commit-comments-GitHub-example.png"
+    src="/images/Octomind-test-results-commit-comments-GitHub-example.png"
     alt="Example of Octomind test results in a github pull request comment"
   />
 </Frame>
@@ -68,7 +68,7 @@ It will give showcase test step snapshots to understand what the execution did e
 
 <Frame caption="failed test result detail, auto-playing all snapshots taken during execution, 08/2024">
   <img
-    src="images/accounts/test-result-failed.png"
+    src="/images/accounts/test-result-failed.png"
     alt="failed test result detail, auto-playing all snapshots taken during execution, 08/2024"
   />
 </Frame>
@@ -91,7 +91,7 @@ In the `debug` tab you can see advanced options to find the issues in your app. 
 <Frame caption="Test result debug tab, 08/2024">
   <img
     width="500"
-    src="images/accounts/debug-tab-failed.png"
+    src="/images/accounts/debug-tab-failed.png"
     alt="test result debug tab, 08/2024"
   />
 </Frame>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -246,7 +246,7 @@ icon: "sparkles"
 
 <Frame caption="AI agent informs about its progress, screenshot 11/2023">
   <img
-    src="images/changelog/agent-progress.png"
+    src="/images/changelog/agent-progress.png"
     alt="AI agent informs about its progress"
   />
 </Frame>
@@ -256,7 +256,7 @@ icon: "sparkles"
 - `What's new` modal notification after log-in added
 
 <Frame caption="New features modal after log-in, screenshot 11/2023">
-  <img src="images/changelog/whatsnew-modal-1.png" alt="New features modal" />
+  <img src="/images/changelog/whatsnew-modal-1.png" alt="New features modal" />
 </Frame>
 
 ## 2023-11-14
@@ -267,7 +267,7 @@ icon: "sparkles"
 
 <Frame caption="Relaunch AI discovery based on your comments, screenshot 11/2023">
   <img
-    src="images/changelog/comments-screenshot.png"
+    src="/images/changelog/comments-screenshot.png"
     alt="Relaunch AI discovery based on comments"
   />
 </Frame>
@@ -279,7 +279,7 @@ icon: "sparkles"
 
 <Frame caption="In-app screenshot carousel in test report detail, screenshot 11/2023">
   <img
-    src="images/changelog/screenshot-carousel.png"
+    src="/images/changelog/screenshot-carousel.png"
     alt="In-app screenshot carousel in test report detail"
   />
 </Frame>
@@ -294,7 +294,7 @@ icon: "sparkles"
 
 <Frame caption="Previous comments in PR are collapsed, screenshot 11/2023">
   <img
-    src="images/changelog/collapse-previous.png"
+    src="/images/changelog/collapse-previous.png"
     alt="Previous comments in PR are collapsed"
   />
 </Frame>
@@ -308,7 +308,7 @@ icon: "sparkles"
 
 <Frame caption="Test case chaining for AI test case discovery, screenshot 10/2023">
   <img
-    src="images/changelog/test-case-chaining.png"
+    src="/images/changelog/test-case-chaining.png"
     alt="Test case chaining for AI test discovery"
   />
 </Frame>
@@ -329,7 +329,7 @@ icon: "sparkles"
 
 <Frame caption="Choose your first tests option at set-up, screenshot 10/2023">
   <img
-    src="images/changelog/test-selection-at-setup.png"
+    src="/images/changelog/test-selection-at-setup.png"
     alt="Choose your first test option at the set-up of Octomind"
   />
 </Frame>
@@ -351,7 +351,7 @@ icon: "sparkles"
 
 <Frame caption="Onboarding feedback thumbs up/down, screenshot 10/2023">
   <img
-    src="images/changelog/onboarding-thumbs.png"
+    src="/images/changelog/onboarding-thumbs.png"
     alt="onboarding thumbs up/down feedback modal"
   />
 </Frame>
@@ -410,7 +410,7 @@ icon: "sparkles"
 
 <Frame caption="Sidebar navigation added to the UI, screenshot 09/2023">
   <img
-    src="images/sidebar-example.png"
+    src="/images/sidebar-example.png"
     alt="new sidebar navigation in the octomind app"
   />
 </Frame>
@@ -429,7 +429,7 @@ icon: "sparkles"
 
 <Frame caption="Scheduling feedback sessions directly from the app, screenshot 08/2023">
   <img
-    src="images/schedule-feedback-sesh.png"
+    src="/images/schedule-feedback-sesh.png"
     alt="scheduling feedback session directly from the app"
   />
 </Frame>
@@ -443,7 +443,7 @@ icon: "sparkles"
 
 <Frame caption="Free promting window for test case discovery, screenshot 08/2023">
   <img
-    src="images/free-prompting-UX.png"
+    src="/images/free-prompting-UX.png"
     alt="free prompting window for test case discovery"
   />
 </Frame>
@@ -456,7 +456,7 @@ icon: "sparkles"
 
 <Frame caption="Example of the new Octomind app welcome screen, screenshot 08/2023">
   <img
-    src="images/welcome-page-UX.png"
+    src="/images/welcome-page-UX.png"
     alt="Example of an Octomind app welcome page"
   />
 </Frame>
@@ -473,5 +473,5 @@ icon: "sparkles"
 - Test database introduced - collection of test cases displayed on the app welcome page:
 
 <Frame caption="Example test cases displayed within a test database, screenshot 08/2023">
-  <img src="images/test-database-example.png" alt="test database example" />
+  <img src="/images/test-database-example.png" alt="test database example" />
 </Frame>

--- a/debugtopus.mdx
+++ b/debugtopus.mdx
@@ -13,13 +13,13 @@ stepping through the code once our tests have identified an issue.
 Click on `run locally` to get a shell script snippet which you can use to install and start Debugtopus.
 
 <Frame caption="screenshot 02/2024">
-  <img src="images/test-result-failure.png" alt="screenshot 02/2024" />
+  <img src="/images/test-result-failure.png" alt="screenshot 02/2024" />
 </Frame>
 
 Click on "copy to clipboard".
 
 <Frame caption="screenshot 02/2024">
-  <img src="images/screenshot-run-locally.png" alt="screenshot 02/2024" />
+  <img src="/images/screenshot-run-locally.png" alt="screenshot 02/2024" />
 </Frame>
 
 ## 2. Start test locally
@@ -28,7 +28,7 @@ Open a terminal window and paste the shell script from your clipboard.
 
 <Frame caption="screenshot 02/2024">
   <img
-    src="images/Terminal-run-locally-npx-command-pasted.png"
+    src="/images/Terminal-run-locally-npx-command-pasted.png"
     alt="screenshot 02/2024"
   />
 </Frame>
@@ -40,7 +40,7 @@ e.g. _localhost:3000/signin_.
 
 <Frame caption="screenshot 02/2024">
   <img
-    src="images/Terminal-run-locally-npx-command-url-adjusted.png"
+    src="/images/Terminal-run-locally-npx-command-url-adjusted.png"
     alt="screenshot 02/2024"
   />
 </Frame>
@@ -52,7 +52,7 @@ the Debugtopus package and its dependencies on your computer. You have to confir
 
 <Frame caption="Install Debugtopus">
   <img
-    src="images/Debugtopus-install.png"
+    src="/images/Debugtopus-install.png"
     alt="Debugtopus install screenshot"
   />
 </Frame>
@@ -68,14 +68,14 @@ first run will take some time to complete.
 Click the `run` button which is displayed on the right side of the test case to run your test.
 
 <Frame caption="Run test">
-  <img src="images/Playwright-run-testcase.png" alt="Run test screenshot" />
+  <img src="/images/Playwright-run-testcase.png" alt="Run test screenshot" />
 </Frame>
 
 Now the Playwright UI is shown.
 
 <Frame caption="Playwright UI screenshot">
   <img
-    src="images/Trace-viewer-screenshot-082023.png"
+    src="/images/Trace-viewer-screenshot-082023.png"
     alt="Playwright UI screenshot"
   />
 </Frame>

--- a/edit-test-case.mdx
+++ b/edit-test-case.mdx
@@ -114,7 +114,7 @@ Btw, we will warn you if you try to leave without saving the test case.
 
 <Frame caption="'save & run' the test to validate and save changes, screenshot 08/2024">
   <img
-    src="images/editing/save-run.png"
+    src="/images/editing/save-run.png"
     alt="Save and run the test case"
     width="300px"
   />
@@ -124,7 +124,7 @@ Btw, we will warn you if you try to leave without saving the test case.
 
 <Frame caption="'run only' to validate the test before saving it, screenshot 08/2024">
   <img
-    src="images/editing/save-run-only.png"
+    src="/images/editing/save-run-only.png"
     alt="Run only to validate the test before saving it"
     width="300px"
   />

--- a/more-info/octo-dictionary.mdx
+++ b/more-info/octo-dictionary.mdx
@@ -45,7 +45,7 @@ You can run any draft or published test case by clicking the run button. This fu
 A Test case is the Octomind base entity and it models a user flow.
 
 <Frame caption="Anatomy of a test case, 03/2024">
-  <img src="images/TestCase.png" alt="anatomy of a test case" />
+  <img src="/images/TestCase.png" alt="anatomy of a test case" />
 </Frame>
 
 A test case can have multiple states:
@@ -78,5 +78,5 @@ A user flow is something a user would typically do in your web app. Examples wou
 to book a hotel on a hotel booking page.
 
 <Frame caption="example of a user flow, 03/2024">
-  <img src="images/user-flow.png" alt="example of a user flow" />
+  <img src="/images/user-flow.png" alt="example of a user flow" />
 </Frame>

--- a/new-test-case.mdx
+++ b/new-test-case.mdx
@@ -12,7 +12,7 @@ Go into the test case and hover over the `suggest more` icon - a button will app
 
 <Frame caption="Have the AI agent suggest more test cases, 08/2024">
   <img
-    src="images/setup/setup-11-suggest-more.png"
+    src="/images/setup/setup-11-suggest-more.png"
     alt="have AI suggest more test cases"
   />
 </Frame>
@@ -23,7 +23,7 @@ The AI agent status indicator will display what's going on.
 
 <Frame caption="AI agent informs what it does, 08/2024">
   <img
-    src="images/prompting/suggesting-more-agent-running.png"
+    src="/images/prompting/suggesting-more-agent-running.png"
     alt="AI agent status indicator"
   />
 </Frame>
@@ -33,7 +33,7 @@ The new test will appear grouped by the originating test. The AI agent has auto-
 Help the AI agent when it couldn't quite nail the auto-generation - **yellow alert** highlights a failed step generation. See how in the [edit test case](/edit-test-case) section.
 
 <Frame caption="New suggested tests, 08/2024">
-  <img src="images/prompting/suggested-tests.png" alt="New suggested tests" />
+  <img src="/images/prompting/suggested-tests.png" alt="New suggested tests" />
 </Frame>
 
 ## Prompt our AI agent to generate new tests
@@ -42,7 +42,7 @@ The fastest way to create a new bespoke test is to have it AI generated from you
 
 <Frame caption="Create new test case by prompting the AI agent, screenshot 07/2024">
   <img
-    src="images/prompting/create-new-test.png"
+    src="/images/prompting/create-new-test.png"
     alt="AI agent informs about its progress"
   />
 </Frame>
@@ -51,7 +51,7 @@ While our `AI agent` generates the steps of your test cases, it informs you abou
 
 <Frame caption="AI agent informs about its progress, screenshot 07/2024">
   <img
-    src="images/prompting/AI-Agent-generating-steps.png"
+    src="/images/prompting/AI-Agent-generating-steps.png"
     alt="AI agent informs about its progress as it generates steps"
   />
 </Frame>
@@ -64,7 +64,7 @@ If the AI agent generated wrong steps or signals a failed step with a yellow ale
 
 <Frame caption="A generated test step failed, hightlighted by yellow alert, screenshot 07/2024">
   <img
-    src="images/prompting/failed-test-step.png"
+    src="/images/prompting/failed-test-step.png"
     alt="A generated step failed and shows a yellow alert"
   />
 </Frame>
@@ -84,7 +84,7 @@ This test is also created on the fly for a **new project**, if we detect a login
 
 <Frame caption="Test user credentials for login test, screenshot 07/2024">
   <img
-    src="images/prompting/login-variables.png"
+    src="/images/prompting/login-variables.png"
     alt="Login test user variables for login test"
   />
 </Frame>
@@ -103,7 +103,7 @@ This is how you do it:
 
 <Frame caption="Test case chaining, screenshot 07/2024">
   <img
-    src="images/prompting/define-dependency.png"
+    src="/images/prompting/define-dependency.png"
     alt="Test case chaining"
     width="300px"
   />
@@ -138,7 +138,7 @@ This is how you do it:
 
 <Frame caption="Toggle button to activate your test case, screenshot 07/2024">
   <img
-    src="images/prompting/toggle-button.png"
+    src="/images/prompting/toggle-button.png"
     alt="Toggle button to activate test"
   />
 </Frame>
@@ -152,7 +152,7 @@ Once you finished your recording, just copy and paste the whole code into the co
 
 <Frame caption="Test case recording, screenshot 02/2024">
   <img
-    src="images/Test-case-recording.png"
+    src="/images/Test-case-recording.png"
     alt="Test case recording"
     width="300px"
   />

--- a/test-case-creation-strategy.mdx
+++ b/test-case-creation-strategy.mdx
@@ -20,7 +20,7 @@ Always use the `Discover` button on the overview page. It gives you a head start
 
 <Frame caption="Have AI discover first 3 test cases from overiew page, 07/2024">
   <img
-    src="images/setup/setup-6-discover.png"
+    src="/images/setup/setup-6-discover.png"
     alt="have AI discover test cases from overview page"
   />
 </Frame>
@@ -31,7 +31,7 @@ The AI agent will discover up to 3 new tests based on the one you started it fro
 
 <Frame caption="Have the AI agent suggest more test cases, 08/2024">
   <img
-    src="images/setup/setup-11-suggest-more.png"
+    src="/images/setup/setup-11-suggest-more.png"
     alt="have AI suggest more test cases"
   />
 </Frame>
@@ -52,7 +52,7 @@ Use the `create test case` button on the **overview page** or on the **test case
 
 <Frame caption="Create new test case from the overview page, 07/2024">
   <img
-    src="images/prompting/create-new-test.png"
+    src="/images/prompting/create-new-test.png"
     alt="create new test cases from the overview page, 07/2004"
   />
 </Frame>
@@ -79,7 +79,7 @@ This way the test runner as well as the AI Agent are using pre-play to execute d
 
 <Frame caption="'accept cookies' test is first in the chain - it does not have a dependency, 08/2024">
   <img
-    src="images/bestpractice/dependency-01-accept-cookies.png"
+    src="/images/bestpractice/dependency-01-accept-cookies.png"
     alt="no dependency for accept cookies"
     width="300px"
   />
@@ -89,7 +89,7 @@ This way the test runner as well as the AI Agent are using pre-play to execute d
 
 <Frame caption="'login' test depends on 'accept cookies', 08/2024">
   <img
-    src="images/bestpractice/dependency-02-login.png"
+    src="/images/bestpractice/dependency-02-login.png"
     alt="login test depends on accept cookies test"
     width="300px"
   />
@@ -99,7 +99,7 @@ This way the test runner as well as the AI Agent are using pre-play to execute d
 
 <Frame caption="'navigate to returns' test depends on 'login' test, 08/2024">
   <img
-    src="images/bestpractice/dependency-03-navigate-returns.png"
+    src="/images/bestpractice/dependency-03-navigate-returns.png"
     alt="Navigate to returns test depends on login test"
     width="300px"
   />
@@ -125,7 +125,7 @@ You can add missing steps by clicking the `+ add step` button and choosing the d
 More details can be found in the [editing test cases](/edit-test-case) section.
 
 <Frame caption="add missing steps, 08/2024">
-  <img src="images/bestpractice/add-steps.png" alt="add missing steps" />
+  <img src="/images/bestpractice/add-steps.png" alt="add missing steps" />
 </Frame>
 
 <div class="mt-8" />
@@ -148,7 +148,7 @@ You can find the `run locally` button in the `debug` tab of your test case. Find
 
 <Frame caption="'run locally' in test detail view, 08/2024">
   <img
-    src="images/bestpractice/run-locally.png"
+    src="/images/bestpractice/run-locally.png"
     alt="run locally in test detail view"
     width="300px"
   />
@@ -159,7 +159,7 @@ Then you can copy the locator.
 
 <Frame caption="Playwright locator tool when running locally, 02/2024">
   <img
-    src="images/bestpractice/run-locally-Playwright-selector.png"
+    src="/images/bestpractice/run-locally-Playwright-selector.png"
     alt="Playwright locator tool when running locally"
   />
 </Frame>


### PR DESCRIPTION
we should always try to embed imgs via `<img src="/images/... />` and not `<img src="images/... />` 

currently nested pages cannot resolve the imgs correclty:
<img width="539" alt="Screenshot 2024-08-14 at 10 17 03" src="https://github.com/user-attachments/assets/ce8db8a2-eb25-4bad-b2e8-388552916444">

should work with relative paths --> the leading slash ;) 
<img width="566" alt="Screenshot 2024-08-14 at 10 16 52" src="https://github.com/user-attachments/assets/4e3177af-47f4-4d26-acde-cfc40a30ddca">

