### PR TITLE
Remove auth subdomains

### DIFF
--- a/bug-bounty-program.mdx
+++ b/bug-bounty-program.mdx
@@ -17,7 +17,7 @@ vulnerabilities, you are helping us protect our users and improve our services.
 
 ### In Scope:
 
-- All services under the domain **octomind.dev**
+- All services under the domain **octomind.dev**, except all subdomains starting with **auth.**
 - SaaS platform, APIs, and related integrations
 
 ### Out of Scope:
@@ -30,7 +30,8 @@ vulnerabilities, you are helping us protect our users and improve our services.
 
 ## Rewards
 
-Our reward program is based on the severity and impact of the vulnerability. Rewards will be determined by our internal assessment team, taking into account:
+Our reward program is based on the severity and impact of the vulnerability. Rewards will be determined by our internal assessment team, 
+taking into account:
 
 - Vulnerability criticality
 - Potential impact on our users and infrastructure

--- a/bug-bounty-program.mdx
+++ b/bug-bounty-program.mdx
@@ -30,7 +30,7 @@ vulnerabilities, you are helping us protect our users and improve our services.
 
 ## Rewards
 
-Our reward program is based on the severity and impact of the vulnerability. Rewards will be determined by our internal assessment team, 
+Our reward program is based on the severity and impact of the vulnerability. Rewards will be determined by our internal assessment team,
 taking into account:
 
 - Vulnerability criticality


### PR DESCRIPTION
Remove auth subdomains from bug bounty scope as all those reports relate to propel auth itself